### PR TITLE
Fix edge case in dCGH

### DIFF
--- a/genotyper.py
+++ b/genotyper.py
@@ -469,6 +469,8 @@ def assess_complex_locus(overlapping_call_clusts, g, contig, filt, plot_dir="./p
                 mus = np.mean(X,1)
                 if g.is_segdup(contig, s, e) or np.mean(mus)>=3 or np.amax(mus) >2.5:
                     Xs, s_idx_s, s_idx_e = g.get_sunk_gt_matrix(contig, s, e)
+                    if Xs.size == 0:
+                        continue
                     gXs = g.GMM_genotype(Xs)
                     if gXs.n_clusts == 1:
                         continue


### PR DESCRIPTION
Fixed issue in assess_complex_locus function for dCGH where GMM_genotype would try to genotype an empty matrix by calculating linkage for an array of nans, resulting in a core dump.

This fix checks to make sure the matrix returned by get_sunk_gt_matrix is not empty before genotyping.
